### PR TITLE
Fix error when attempting to DELETE only one character left

### DIFF
--- a/module/cli_input.c
+++ b/module/cli_input.c
@@ -287,10 +287,7 @@ void INPUT_Delete()
 	if ((Input.CurBuffer->CursorInBuffer != Input.CurBuffer->BufferCount) && (!INPUT_IsEmpty()))
 	{
 		INPUT_CursorShift(1);
-		if(Input.CurBuffer->CursorInBuffer != Input.CurBuffer->BufferCount)
-		{
-			CLI_PutChar(Input.CurBuffer->Data[Input.CurBuffer->CursorInBuffer - 1]);
-		}
+		CLI_PutChar(Input.CurBuffer->Data[Input.CurBuffer->CursorInBuffer - 1]);
 		INPUT_RemChar();
 	}	
 }


### PR DESCRIPTION
Fixes an issue where pressing DEL with a single character in the input would move the cursor left instead of deleting the character.