### PR TITLE
Fixes confusion between DEL and BS char and key codes

### DIFF
--- a/def_config/terminal_config.h
+++ b/def_config/terminal_config.h
@@ -45,6 +45,7 @@ extern void _reset_fcn();
 #define TERM_ARGS_BUF_SIZE		(10)				// Max number of arguments in one command
 #define TERM_ARG_SIZE			(15)				// Max number character of one arguments
 #define CHAR_INTERRUPT			TERM_KEY_ESCAPE 	// Abort execute command key-code symbol
+#define CHAR_BACKSPACE			'\x08'			// Backspace char
 #define STRING_TERM_ENTER		"\n\r"				// String new line
 #define STRING_TERM_ARROW		">> "				// String arrow enter
 #define RESET_FCN				_reset_fcn			// Reset CPU Function

--- a/examples/Coocox_lcp1227/terminal_config.h
+++ b/examples/Coocox_lcp1227/terminal_config.h
@@ -45,6 +45,7 @@ extern void _reset_fcn();
 #define TERM_ARGS_BUF_SIZE		(10)				// Max number of arguments in one command
 #define TERM_ARG_SIZE			(15)				// Max number character of one arguments
 #define CHAR_INTERRUPT			TERM_KEY_ESCAPE 	// Abort execute command key-code symbol
+#define CHAR_BACKSPACE			'\x08'			// Backspace char
 #define STRING_TERM_ENTER		"\n\r"				// String new line
 #define STRING_TERM_ARROW		">> "				// String arrow enter
 #define RESET_FCN				_reset_fcn			// Reset CPU Function

--- a/examples/Coocox_stm32f4/terminal_config.h
+++ b/examples/Coocox_stm32f4/terminal_config.h
@@ -45,6 +45,7 @@ extern void _reset_fcn();
 #define TERM_ARGS_BUF_SIZE		(10)				// Max number of arguments in one command
 #define TERM_ARG_SIZE			(15)				// Max number character of one arguments
 #define CHAR_INTERRUPT			TERM_KEY_ESCAPE 	// Abort execute command key-code symbol
+#define CHAR_BACKSPACE			'\x08'			// Backspace char
 #define STRING_TERM_ENTER		"\n\r"				// String new line
 #define STRING_TERM_ARROW		">> "				// String arrow enter
 #define RESET_FCN				_reset_fcn			// Reset CPU Function

--- a/examples/Proteus_emulate/atmega32/src_prj/terminal_config.h
+++ b/examples/Proteus_emulate/atmega32/src_prj/terminal_config.h
@@ -44,6 +44,7 @@
 #define TERM_ARGS_BUF_SIZE		(20)				// Max number of arguments in one command
 #define TERM_ARG_SIZE			(15)				// Max number character of one arguments
 #define CHAR_INTERRUPT			TERM_KEY_ESCAPE 	// Abort execute command key-code symbol
+#define CHAR_BACKSPACE			'\x08'			// Backspace char
 #define STRING_TERM_ENTER		"\n\r"				// String new line
 #define STRING_TERM_ARROW		">> "				// String arrow enter
 #define RESET_FCN()									// Reset CPU Function

--- a/examples/dev_cpp/terminal_config.h
+++ b/examples/dev_cpp/terminal_config.h
@@ -44,6 +44,7 @@
 #define TERM_ARGS_BUF_SIZE		(20)				// Max number of arguments in one command
 #define TERM_ARG_SIZE			(15)				// Max number character of one arguments
 #define CHAR_INTERRUPT			TERM_KEY_ESCAPE 	// Abort execute command key-code symbol
+#define CHAR_BACKSPACE			'\x08'			// Backspace char
 #define STRING_TERM_ENTER		"\n\r"				// String new line
 #define STRING_TERM_ARROW		">> "				// String arrow enter
 #define RESET_FCN()									// Reset CPU Function

--- a/module/cli_input.c
+++ b/module/cli_input.c
@@ -34,9 +34,9 @@ static void _AddChar(char c)
 
 static void _RemChar()
 {
-	CLI_PutChar(TERM_KEY_BACKSPACE);
+	CLI_PutChar(CHAR_BACKSPACE);
     CLI_PutChar(' ');
-    CLI_PutChar(TERM_KEY_BACKSPACE);
+    CLI_PutChar(CHAR_BACKSPACE);
     
 	Input.CurBuffer->CursorInBuffer--;
 	Input.CurBuffer->BufferCount--;
@@ -70,7 +70,7 @@ void INPUT_Refresh(const char* newCmd)
 		}
 		
 		for(uint8_t i = 0; i < cntSpcChar; i++)
-        	{CLI_PutChar(TERM_KEY_BACKSPACE);}	
+        	{CLI_PutChar(CHAR_BACKSPACE);}	
         
 #if 0
 		CLI_DPrintf("\r\nNewCmd: %s", newCmd);
@@ -115,7 +115,7 @@ void INPUT_RemChar()
 
 		for(uint8_t pos = 0; pos < Input.CurBuffer->BufferCount - tmpPos; pos++)
 		{
-            CLI_PutChar(TERM_KEY_LSHIFT);
+            CLI_PutChar(CHAR_BACKSPACE);
 			Input.CurBuffer->CursorInBuffer--;
 		}
 	}
@@ -148,7 +148,7 @@ void INPUT_AddChar(char c)
 
 		for(uint8_t pos = 0; pos < Input.CurBuffer->BufferCount - tmpPos; pos++)
 		{
-            CLI_PutChar(TERM_KEY_LSHIFT);
+            CLI_PutChar(CHAR_BACKSPACE);
 			Input.CurBuffer->CursorInBuffer--;
 		}
 	}
@@ -250,7 +250,7 @@ void INPUT_CursorToHome()
 {
 	while(Input.CurBuffer->CursorInBuffer > 0)
 	{
-		CLI_PutChar(TERM_KEY_LSHIFT);
+		CLI_PutChar(CHAR_BACKSPACE);
 		INPUT_CursorShift(-1);
 	}
 }
@@ -269,7 +269,7 @@ void INPUT_CursorToLeft()
 	if (Input.CurBuffer->CursorInBuffer > 0)
 	{
 		INPUT_CursorShift(-1);
-        CLI_PutChar(TERM_KEY_LSHIFT);
+        CLI_PutChar(CHAR_BACKSPACE);
 	}
 }
 
@@ -287,6 +287,10 @@ void INPUT_Delete()
 	if ((Input.CurBuffer->CursorInBuffer != Input.CurBuffer->BufferCount) && (!INPUT_IsEmpty()))
 	{
 		INPUT_CursorShift(1);
+		if(Input.CurBuffer->CursorInBuffer != Input.CurBuffer->BufferCount)
+		{
+			CLI_PutChar(Input.CurBuffer->Data[Input.CurBuffer->CursorInBuffer - 1]);
+		}
 		CLI_PutChar(Input.CurBuffer->Data[Input.CurBuffer->CursorInBuffer - 1]);
 		INPUT_RemChar();
 	}	


### PR DESCRIPTION
When the examples are tested with a Linux terminal, they fail when handling `DEL` or `BS` keys. From what I know, it's because the `DEL` keycode (0x7F) is interpreted in a different way in Linux.

I created another macro in the configuration files, `CHAR_BACKSPACE`, with the more general value '\x08' and placed it instead of `TERM_KEY_BACKSPACE` and `TERM_KEY_LSHIFT` in `cli_input.c`. After this changes, the examples are working properly in Linux and Windows.